### PR TITLE
Added Bug Bounty Directory

### DIFF
--- a/web-appsec/bug-bounty-platforms-programs.md
+++ b/web-appsec/bug-bounty-platforms-programs.md
@@ -4,6 +4,8 @@
 
 {% embed url="https://disclose.io/programs/" %}
 
+{% embed url="https://bugbountydirectory.com/" %}
+
 {% embed url="https://bbradar.io/" %}
 
 {% embed url="https://bugbase.ai/programs" %}


### PR DESCRIPTION
BugBountyDirectory.com is a list of Public Bug Bounty and Responsible Disclosure programs that are not listed on major platforms like HackerOne or Bugcrowd.